### PR TITLE
Move exchange properties under a common key

### DIFF
--- a/bin/process-manifests.sh
+++ b/bin/process-manifests.sh
@@ -143,14 +143,14 @@ function process_manifests() {
 
             jq "{\"$manifest_type\": .}" $manifest_path > $v_manifest_path
 
-            jq ".\"git-commit\" = \"$GIT_COMMIT_CURRENT\"" $v_manifest_path \
+            jq ".exchange.\"git-commit\" = \"$GIT_COMMIT_CURRENT\"" $v_manifest_path \
                 > $tempfile && mv $tempfile $v_manifest_path
 
-            jq ".\"rootfs-hash\" = \"sha384:$shasum\" | .\"rootfs-url\" = \"$EXCHANGE_DOWNLOAD_URL/$v_manifest_name.tgz\"" $v_manifest_path \
+            jq ".exchange.\"rootfs-hash\" = \"sha384:$shasum\" | .\"rootfs-url\" = \"$EXCHANGE_DOWNLOAD_URL/$v_manifest_name.tgz\"" $v_manifest_path \
                 > $tempfile && mv $tempfile $v_manifest_path
 
             invocation_schema=$( derive_invocation_schema $manifest_type $manifest_path )
-            jq ".\"invocation-schema\" = $invocation_schema" $v_manifest_path \
+            jq ".exchange.\"invocation-schema\" = $invocation_schema" $v_manifest_path \
                 > $tempfile && mv $tempfile $v_manifest_path
             >&2 echo "Invocation schema generated for $manifest_type $manifest_name"
 

--- a/bin/process-manifests.sh
+++ b/bin/process-manifests.sh
@@ -127,7 +127,7 @@ function process_manifests() {
             tempfile=$tempdir/tempfile
 
             if [ "$manifest_type" == "gear" ]; then
-                docker_image="$( jq -r '.custom."flywheel-exchange"."docker-image"' $manifest_path )"
+                docker_image="$( jq -r '.custom."docker-image"' $manifest_path )"
             else
                 docker_image="$( jq -r '."docker-image"' $manifest_path )"
             fi

--- a/gears/flywheel/afq-demo.json
+++ b/gears/flywheel/afq-demo.json
@@ -154,8 +154,6 @@
         }
     },
     "custom": {
-        "flywheel-exchange": {
-            "docker-image": "flywheel/afq-demo"
-        }
+        "docker-image": "flywheel/afq-demo"
     }
 }

--- a/gears/flywheel/cortex-demo.json
+++ b/gears/flywheel/cortex-demo.json
@@ -21,8 +21,6 @@
         }
     },
     "custom": {
-        "flywheel-exchange": {
-            "docker-image": "flywheel/cortex-demo"
-        }
+        "docker-image": "flywheel/cortex-demo"
     }
 }

--- a/gears/flywheel/dtiinit-demo.json
+++ b/gears/flywheel/dtiinit-demo.json
@@ -110,8 +110,6 @@
         }
     },
     "custom": {
-        "flywheel-exchange": {
-            "docker-image": "flywheel/dtiinit-demo"
-        }
+        "docker-image": "flywheel/dtiinit-demo"
     }
 }

--- a/gears/flywheel/example-gear.json
+++ b/gears/flywheel/example-gear.json
@@ -67,9 +67,7 @@
 		}
     },
     "custom": {
-        "flywheel-exchange": {
-            "docker-image": "flywheel/example-gear"
-        }
+        "docker-image": "flywheel/example-gear"
 	}
 }
 

--- a/gears/flywheel/hippovol-demo.json
+++ b/gears/flywheel/hippovol-demo.json
@@ -21,8 +21,6 @@
         }
     },
     "custom": {
-        "flywheel-exchange": {
-            "docker-image": "flywheel/hippovol-demo"
-        }
+        "docker-image": "flywheel/hippovol-demo"
     }
 }

--- a/gears/flywheel/reconall-demo.json
+++ b/gears/flywheel/reconall-demo.json
@@ -21,8 +21,6 @@
         }
     },
     "custom": {
-        "flywheel-exchange": {
-            "docker-image": "flywheel/reconall-demo"
-        }
+        "docker-image": "flywheel/reconall-demo"
     }
 }

--- a/gears/flywheel/spectroscopy-demo.json
+++ b/gears/flywheel/spectroscopy-demo.json
@@ -21,8 +21,6 @@
         }
     },
     "custom": {
-        "flywheel-exchange": {
-            "docker-image": "flywheel/spectroscopy-demo"
-        }
+        "docker-image": "flywheel/spectroscopy-demo"
     }
 }

--- a/gears/scitran/afq.json
+++ b/gears/scitran/afq.json
@@ -197,8 +197,6 @@
         }
     },
     "custom": {
-        "flywheel-exchange": {
-            "docker-image": "scitran/afq"
-        }
+        "docker-image": "scitran/afq"
     }
 }

--- a/gears/scitran/dcm2niix.json
+++ b/gears/scitran/dcm2niix.json
@@ -22,8 +22,6 @@
         }
     },
     "custom": {
-        "flywheel-exchange": {
-            "docker-image": "scitran/dcm2niix"
-        }
+        "docker-image": "scitran/dcm2niix"
     }
 }

--- a/gears/scitran/dtiinit.json
+++ b/gears/scitran/dtiinit.json
@@ -102,8 +102,6 @@
         }
     },
     "custom": {
-        "flywheel-exchange": {
-            "docker-image": "scitran/dtiinit"
-        }
+        "docker-image": "scitran/dtiinit"
     }
 }

--- a/gears/scitran/parrec-mr-classifier.json
+++ b/gears/scitran/parrec-mr-classifier.json
@@ -21,8 +21,6 @@
         }
     },
     "custom": {
-        "flywheel-exchange": {
-            "docker-image": "scitran/parrec-mr-classifier"
-        }
+        "docker-image": "scitran/parrec-mr-classifier"
     }
 }

--- a/gears/scitran/qa-dtiprep.json
+++ b/gears/scitran/qa-dtiprep.json
@@ -37,8 +37,6 @@
         }
     },
     "custom": {
-        "flywheel-exchange": {
-            "docker-image": "scitran/qa-dtiprep"
-        }
+        "docker-image": "scitran/qa-dtiprep"
     }
 }

--- a/gears/scitran/structural-analysis.json
+++ b/gears/scitran/structural-analysis.json
@@ -20,8 +20,6 @@
     },
     "config": {},
     "custom": {
-        "flywheel-exchange": {
-            "docker-image": "scitran/structural-analysis"
-        }
+        "docker-image": "scitran/structural-analysis"
     }
 }


### PR DESCRIPTION
I think we chatted about this last week; I went ahead & did it while it's early and easy to change.

Exchange-generated properties are now stored under a common key.
This will make it safer for external systems (such as scitran) to integrate directly with these objects.

* `git-commit` --> `exchange.git-commit`
* `rootfs-hash` --> `exchange.rootfs-hash`
* `rootfs-url` --> `exchange.rootfs-url`

I modified the bin script and updated all versioned manifests with some simple `find | xargs | jq` logic.