### PR TITLE
Dockerhub auth

### DIFF
--- a/bin/process-manifests.sh
+++ b/bin/process-manifests.sh
@@ -47,7 +47,7 @@ if [ ! -z "$GCLOUD_SERVICE_ACCOUNT" ]; then
     gcloud auth activate-service-account --key-file $GCLOUD_SERVICE_ACCOUNT_FILE
 fi
 
-if [ ! -z "$DOCKERHUB_USER" -a ! -z "$DOCKERHUB_PASSWORD"]; then
+if [ ! -z "$DOCKERHUB_USER" -a ! -z "$DOCKERHUB_PASSWORD" ]; then
     docker login -u "$DOCKERHUB_USER" -p "$DOCKERHUB_PASSWORD"
 fi
 

--- a/bin/process-manifests.sh
+++ b/bin/process-manifests.sh
@@ -48,7 +48,7 @@ if [ ! -z "$GCLOUD_SERVICE_ACCOUNT" ]; then
 fi
 
 if [ ! -z "$DOCKERHUB_USER" -a ! -z "$DOCKERHUB_PASSWORD" ]; then
-    docker login -u "$DOCKERHUB_USER" -p "$DOCKERHUB_PASSWORD" "$DOCKERHUB_EMAIL"
+    docker login -u "$DOCKERHUB_USER" -p "$DOCKERHUB_PASSWORD" $DOCKERHUB_EMAIL
 fi
 
 set -eu

--- a/bin/process-manifests.sh
+++ b/bin/process-manifests.sh
@@ -47,6 +47,10 @@ if [ ! -z "$GCLOUD_SERVICE_ACCOUNT" ]; then
     gcloud auth activate-service-account --key-file $GCLOUD_SERVICE_ACCOUNT_FILE
 fi
 
+if [ ! -z "$DOCKERHUB_USER" -a ! -z "$DOCKERHUB_PASSWORD"]; then
+    docker login -u "$DOCKERHUB_USER" -p "$DOCKERHUB_PASSWORD"
+fi
+
 set -eu
 
 

--- a/bin/process-manifests.sh
+++ b/bin/process-manifests.sh
@@ -48,7 +48,7 @@ if [ ! -z "$GCLOUD_SERVICE_ACCOUNT" ]; then
 fi
 
 if [ ! -z "$DOCKERHUB_USER" -a ! -z "$DOCKERHUB_PASSWORD" ]; then
-    docker login -u "$DOCKERHUB_USER" -p "$DOCKERHUB_PASSWORD"
+    docker login -u "$DOCKERHUB_USER" -p "$DOCKERHUB_PASSWORD" "$DOCKERHUB_EMAIL"
 fi
 
 set -eu


### PR DESCRIPTION
This is to allow the exchange to build gears hosted from private dockerhub repos. As it stands, the gear author would need to provide read access to the dockerhub account `flywheelexchange` in addition to adding their relevant gear document.

Required options with `docker login` are different between the version supported in circle CI (1.10) and the latest (1.12).

Maybe all docker login parameters should be represented with a single variable instead to preserve the version flexibility and eliminate the inconsistent usage? Open to other approaches as well.