### PR TITLE
Fix 'jq' cmd to respect updated boutiques schema

### DIFF
--- a/bin/process-manifests.sh
+++ b/bin/process-manifests.sh
@@ -133,7 +133,7 @@ function process_manifests() {
             if [ "$manifest_type" == "gear" ]; then
                 docker_image="$( jq -r '.custom."docker-image"' $manifest_path )"
             else
-                docker_image="$( jq -r '."docker-image"' $manifest_path )"
+                docker_image="$( jq -r '."container-image"."image"' $manifest_path )"
             fi
 
             container=$( docker create $docker_image /bin/true )


### PR DESCRIPTION
`docker create $docker_image` is failing because the updated boutiques schema (Release 0.4) stores the docker image location at "container-image"."image". This updates the jq command to respect the new schema.