### PR TITLE
Add dcm-convert (v1.0.0) gear

### DIFF
--- a/gears/scitran/dcm-convert.json
+++ b/gears/scitran/dcm-convert.json
@@ -1,0 +1,41 @@
+{
+	"name": "dcm-convert",
+	"label": "SciTran: dcm-convert - DICOM conversion tool",
+	"description": "Uses SciTran's data library (https://github.com/scitran/data) to convert raw DICOM data to a Montage. Can be configured to optionally convert data to NIfTI, or PNG (screenshots) format. Supports Siemens or GE DICOM data.",
+	"maintainer": "Michael Perry <lmperry@stanford.edu>",
+	"author": "Scientific Transparency (RF Dougherty, K Hahn, R Bowen, LM Perry)",
+	"url": "https://github.com/scitran/data",
+	"source": "https://github.com/scitran-apps/dcm-convert",
+	"license": "Apache-2.0",
+	"flywheel": "0",
+	"version": "1.0.0",
+	"config": {
+		"convert_montage": {
+			"description": "Convert selected DICOM archive to MONTAGE format. (Default=true)",
+			"default": true,
+			"type": "boolean"
+		},
+		"convert_nifti": {
+			"description": "Convert selected DICOM archive to to NIfTI format. (Default=false)",
+			"default": false,
+			"type": "boolean"
+		},
+		"convert_png": {
+			"description": "Convert screenshot acquisitions to PNG. (Default=false)",
+			"default": false,
+			"type": "boolean"
+		}
+	},
+	"inputs": {
+		"dicom": {
+			"description": "Archive (.zip) of DICOM files.",
+			"base": "file",
+			"type": {
+				"enum": ["dicom"]
+			}
+		}
+	},
+	"custom": {
+		"docker-image": "scitran/dcm-convert:v1.0.0"
+	}
+}


### PR DESCRIPTION
Uses SciTran's data library (https://github.com/scitran/data) to convert raw DICOM data to a Montage. Can be configured to optionally convert data to NIfTI, or PNG (screenshots) format. Supports Siemens or GE DICOM data.