### PR TITLE
Validate that the docker image specified is valid

### DIFF
--- a/bin/process-manifests.sh
+++ b/bin/process-manifests.sh
@@ -56,12 +56,17 @@ set -eu
 
 function validate_manifest() {
     if [ "$1" == "gear" ]; then
+        # Validate the manifest against the schema
         if [ ! -v GEAR_SCHEMA_PATH ]; then
             >&2 echo "Installing gear schema"
             GEAR_SCHEMA_PATH=$( mktemp )
             curl -s $GEAR_SCHEMA_URL > $GEAR_SCHEMA_PATH
         fi
         python -m jsonschema -i "$2" $GEAR_SCHEMA_PATH
+
+        # Confirm the image is valid.
+        docker_image="$( jq -r '.custom."docker-image"' $2 )"
+        docker run luebken/skopeo skopeo inspect "docker://docker.io/$docker_image"
     elif [ "$1" == "boutique" ]; then
         if [ ! -v BOUTIQUE_SCHEMA_PATH ]; then
             >&2 echo "Installing boutique schema"


### PR DESCRIPTION
Resolves #17 

CI on PRs should make sure the image name is valid. This quick and dirty implementation uses `skopeo` to validate the existence of the image remotely without pulling it down.

I'm not wild about relying on a 3rd party docker image, nor overhead this adds with this quick and dirty implementation. Thoughts @gsfr and @lmperry ?