### PR TITLE
Upgrade to flywheel/mriqc:v0.2

### DIFF
--- a/gears/flywheel/mriqc.json
+++ b/gears/flywheel/mriqc.json
@@ -1,26 +1,37 @@
 {
-    "author": "Poldrack Lab at Stanford University", 
-    "config": {
-    }, 
-    "custom": {
-        "docker-image": "flywheel/mriqc:v0.1"
-    }, 
-    "description": "The package provides a series of image processing workflows to extract and compute a series of NR (no-reference), IQMs (image quality metrics) to be used in QAPs (quality assessment protocols) for MRI (magnetic resonance imaging). This tool extracts a series of IQMs from structural or functional MRI data. Note, this gear only supports the generation of individual scan reports; group reports are not generated.", 
-    "inputs": {
-        "nifti": {
-            "base": "file", 
-            "type": {
-                "enum": [
-                    "nifti"
-                ]
-            }
-        }
-    }, 
-    "label": "MRIQC: NR-IQMs for Functional MRI (mriqc v0.9.0-0)",
-    "license": "BSD-3-Clause", 
-    "maintainer": "Jennifer Reiter <jenniferreiter@invenshure.com>", 
-    "name": "mriqc", 
-    "source": "https://github.com/flywheel-apps/mriqc", 
-    "url": "https://github.com/poldracklab/mriqc", 
-    "version": "0.1"
+  "author": "Oscar Esteban and Krzysztof F. Gorgolewski. Stanford University",
+  "config": {
+    "measurement": {
+      "default": "Functional",
+      "description": "Type of input image. Can be either 'T1w', 'T2w' or 'Functional' (default='Functional').",
+      "type": "string",
+      "enum": [
+        "Functional",
+        "T1w",
+        "T2w"
+      ]
+    }
+  },
+  "custom": {
+    "docker-image": "flywheel/mriqc:v0.2"
+  },
+  "description": "The MRIQC package provides a series of image processing workflows to extract and compute a series of NR (no-reference), IQMs (image quality metrics) to be used in QAPs (quality assessment protocols) for MRI (magnetic resonance imaging). This tool extracts a series of IQMs from structural or functional MRI data. Note, this gear only supports the generation of individual scan reports; group reports are not generated.",
+  "inputs": {
+    "nifti": {
+      "description": "MRI NIfTI file. Input can be a T1w or T2w anatomical file or a Functional.",
+      "base": "file",
+      "type": {
+        "enum": [
+          "nifti"
+        ]
+      }
+    }
+  },
+  "label": "MRIQC: No-reference image quality metrics for quality assessment of MRI (v0.9.4)",
+  "license": "BSD-3-Clause",
+  "maintainer": "Flywheel <support@flywheel.io>",
+  "name": "mriqc",
+  "source": "https://github.com/flywheel-apps/mriqc",
+  "url": "https://github.com/poldracklab/mriqc",
+  "version": "0.2"
 }


### PR DESCRIPTION
https://github.com/flywheel-apps/mriqc/releases/tag/v0.2

adds support for anatomical/structural (T1w, T2w) data. 