### PR TITLE
dcm2niix v0.3.1

### DIFF
--- a/gears/scitran/dcm2niix.json
+++ b/gears/scitran/dcm2niix.json
@@ -8,7 +8,10 @@
   "source": "https://github.com/scitran-apps/dcm2niix",
   "license": "BSD-2-Clause",
   "flywheel": "0",
-  "version": "0.3",
+  "version": "0.3.1",
+  "custom": {
+    "docker-image": "scitran/dcm2niix:v0.3.1"
+  },
   "config": {
     "decompress_dicoms": {
       "default": false,
@@ -92,8 +95,5 @@
         ]
       }
     }
-  },
-  "custom": {
-    "docker-image": "scitran/dcm2niix:v0.3"
   }
 }


### PR DESCRIPTION
https://github.com/scitran-apps/dcm2niix/releases/tag/v0.3.1