### PR TITLE
Update mriqc to v0.3

### DIFF
--- a/gears/flywheel/mriqc.json
+++ b/gears/flywheel/mriqc.json
@@ -2,18 +2,19 @@
   "author": "Oscar Esteban and Krzysztof F. Gorgolewski. Stanford University",
   "config": {
     "measurement": {
-      "default": "Functional",
-      "description": "Type of input image. Can be either 'T1w', 'T2w' or 'Functional' (default='Functional').",
+      "default": "auto-detect",
+      "description": "Type of input image. Can be either 'anatomy_t1w', 'anatomy_t2w' or 'functional' (default='auto-detect' - gear will attempt to automatically detect the type of input image. If input does not have a classification value, making auto-detection impossible, the gear will then assume the input type is 'functional').",
       "type": "string",
       "enum": [
-        "Functional",
-        "T1w",
-        "T2w"
+        "auto-detect",
+        "functional",
+        "anatomy_t1w",
+        "anatomy_t2w"
       ]
     }
   },
   "custom": {
-    "docker-image": "flywheel/mriqc:v0.2"
+    "docker-image": "flywheel/mriqc:v0.3"
   },
   "description": "The MRIQC package provides a series of image processing workflows to extract and compute a series of NR (no-reference), IQMs (image quality metrics) to be used in QAPs (quality assessment protocols) for MRI (magnetic resonance imaging). This tool extracts a series of IQMs from structural or functional MRI data. Note, this gear only supports the generation of individual scan reports; group reports are not generated.",
   "inputs": {
@@ -33,5 +34,5 @@
   "name": "mriqc",
   "source": "https://github.com/flywheel-apps/mriqc",
   "url": "https://github.com/poldracklab/mriqc",
-  "version": "0.2"
+  "version": "0.3"
 }


### PR DESCRIPTION
mriqc v0.3 contains the new auto-detection feature and a small reg-ex fix

The flywheel/mriqc:v0.3 Docker build was successful: https://hub.docker.com/r/flywheel/mriqc/builds/
