### PR TITLE
freesurfer-recon-all-0.1.3

### DIFF
--- a/gears/scitran/freesurfer-recon-all.json
+++ b/gears/scitran/freesurfer-recon-all.json
@@ -6,9 +6,10 @@
   "author": "Laboratory for Computational Neuroimaging <freesurfer@nmr.mgh.harvard.edu>",
   "url": "https://surfer.nmr.mgh.harvard.edu",
   "source": "https://github.com/scitran-apps/freesurfer-recon-all",
-  "license": "GPL-2.0",
+  "cite": "For citation information, please visit: https://surfer.nmr.mgh.harvard.edu/fswiki/FreeSurferMethodsCitation.",
+  "license": "Other",
   "flywheel": "0",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "inputs": {
     "anatomical": {
       "description": "Anatomical NIfTI file or DICOM archive.",
@@ -84,6 +85,6 @@
     }
   },
   "custom": {
-    "docker-image": "scitran/freesurfer-recon-all:v0.1.2"
+    "docker-image": "scitran/freesurfer-recon-all:0.1.3"
   }
 }


### PR DESCRIPTION
rename manifest file to have proper `json` extension. https://github.com/scitran-apps/freesurfer-recon-all/releases/tag/0.1.3