### PR TITLE
scitran/dcm2niix:0.5.1_1.0.20180328

### DIFF
--- a/gears/scitran/dcm2niix.json
+++ b/gears/scitran/dcm2niix.json
@@ -8,9 +8,9 @@
   "source": "https://github.com/scitran-apps/dcm2niix",
   "license": "BSD-2-Clause",
   "flywheel": "0",
-  "version": "0.5.0_1.0.20171215",
+  "version": "0.5.1_1.0.20180328",
   "custom": {
-    "docker-image": "scitran/dcm2niix:0.5.0_1.0.20171215"
+    "docker-image": "scitran/dcm2niix:0.5.1_1.0.20180328"
   },
   "config": {
     "decompress_dicoms": {


### PR DESCRIPTION
https://github.com/scitran-apps/dcm2niix/releases/tag/0.5.1_1.0.20180328