### PR TITLE
3 sample gears autogenerated by gearificator

### DIFF
--- a/gears/gearificator/nipype-interfaces-ants-segmentation-n4biasfieldcorrection.json
+++ b/gears/gearificator/nipype-interfaces-ants-segmentation-n4biasfieldcorrection.json
@@ -1,0 +1,117 @@
+{
+  "name": "nipype-interfaces-ants-segmentation-n4biasfieldcorrection", 
+  "description": "N4 is a variant of the popular N3 (nonparameteric nonuniform normalization)", 
+  "author": "Yaroslav O. Halchenko", 
+  "maintainer": "Yaroslav O. Halchenko <debian@onerussian.com>", 
+  "license": "BSD-3-Clause", 
+  "version": "0.0.2.nipype.1.0.3.1", 
+  "config": {
+    "args": {
+      "type": "string", 
+      "description": "Additional parameters to the command", 
+      "optional": true
+    }, 
+    "bspline_fitting_distance": {
+      "type": "number", 
+      "description": "Bspline fitting distance", 
+      "optional": true
+    }, 
+    "bspline_order": {
+      "type": "integer", 
+      "description": "Bspline order", 
+      "optional": true
+    }, 
+    "convergence_threshold": {
+      "type": "number", 
+      "description": "Convergence threshold", 
+      "optional": true
+    }, 
+    "copy_header": {
+      "type": "boolean", 
+      "description": "copy headers of the original image into the output (corrected) file"
+    }, 
+    "dimension": {
+      "type": "integer", 
+      "description": "image dimension (2, 3 or 4) [default=3]", 
+      "default": 3, 
+      "enum": [
+        3, 
+        2, 
+        4
+      ]
+    }, 
+    "n_iterations": {
+      "type": "array", 
+      "description": "N iterations", 
+      "optional": true, 
+      "items": {
+        "type": "integer"
+      }
+    }, 
+    "num_threads": {
+      "type": "integer", 
+      "description": "Number of ITK threads to use [default=1]", 
+      "default": 1
+    }, 
+    "output_image": {
+      "type": "string", 
+      "description": "output file name", 
+      "optional": true
+    }, 
+    "save_bias": {
+      "type": "boolean", 
+      "description": "True if the estimated bias should be saved to file.", 
+      "optional": true
+    }, 
+    "shrink_factor": {
+      "type": "integer", 
+      "description": "Shrink factor", 
+      "optional": true
+    }
+  }, 
+  "inputs": {
+    "bias_image": {
+      "description": "Filename for the estimated bias.", 
+      "optional": true, 
+      "base": "file"
+    }, 
+    "input_image": {
+      "description": "input for bias correction. Negative values or values close to zero should be processed prior to correction", 
+      "base": "file"
+    }, 
+    "mask_image": {
+      "description": "image to specify region to perform final bias correction in", 
+      "optional": true, 
+      "base": "file"
+    }, 
+    "weight_image": {
+      "description": "image for relative weighting (e.g. probability map of the white matter) of voxels during the B-spline fitting. ", 
+      "optional": true, 
+      "base": "file"
+    }
+  }, 
+  "url": "http://nipype.readthedocs.io/en/1.0.3/interfaces/generated/interfaces.ants/registration.html", 
+  "source": "https://github.com/yarikoptic/gearificator", 
+  "custom": {
+    "gearificator": {
+      "interface": "nipype.interfaces.ants.segmentation:N4BiasFieldCorrection", 
+      "outputs": {
+        "bias_image": {
+          "description": "Estimated bias"
+        }, 
+        "output_image": {
+          "description": "Warped image"
+        }
+      }, 
+      "category": "analysis"
+    }, 
+    "flywheel": {
+      "suite": "nipype:ants"
+    }, 
+    "gear-builder": {
+      "image": "gearificator/nipype-interfaces-ants-segmentation-n4biasfieldcorrection:0.0.2.nipype.1.0.3.1"
+    }, 
+    "docker-image": "gearificator/nipype-interfaces-ants-segmentation-n4biasfieldcorrection:0.0.2.nipype.1.0.3.1"
+  }, 
+  "label": "N4BiasFieldCorrection"
+}

--- a/gears/gearificator/nipype-interfaces-fsl-preprocess-bet.json
+++ b/gears/gearificator/nipype-interfaces-fsl-preprocess-bet.json
@@ -1,0 +1,176 @@
+{
+  "name": "nipype-interfaces-fsl-preprocess-bet", 
+  "label": "FSL BET (Brain Extraction Tool)", 
+  "description": "FSL BET command for skull stripping", 
+  "author": "Yaroslav O. Halchenko", 
+  "maintainer": "Yaroslav O. Halchenko <debian@onerussian.com>", 
+  "license": "Other", 
+  "version": "0.0.2.nipype.1.0.3.1", 
+  "config": {
+    "args": {
+      "type": "string", 
+      "description": "Additional parameters to the command", 
+      "optional": true
+    }, 
+    "center": {
+      "type": "array", 
+      "description": "center of gravity in voxels", 
+      "optional": true, 
+      "items": {
+        "type": "integer"
+      }
+    }, 
+    "frac": {
+      "type": "number", 
+      "description": "fractional intensity threshold", 
+      "optional": true
+    }, 
+    "functional": {
+      "type": "boolean", 
+      "description": "apply to 4D fMRI data", 
+      "optional": true
+    }, 
+    "mask": {
+      "type": "boolean", 
+      "description": "create binary mask image", 
+      "optional": true
+    }, 
+    "mesh": {
+      "type": "boolean", 
+      "description": "generate a vtk mesh brain surface", 
+      "optional": true
+    }, 
+    "no_output": {
+      "type": "boolean", 
+      "description": "Don't generate segmented output", 
+      "optional": true
+    }, 
+    "outline": {
+      "type": "boolean", 
+      "description": "create surface outline image", 
+      "optional": true
+    }, 
+    "output_type": {
+      "type": "string", 
+      "description": "FSL output type [default=NIFTI_GZ]", 
+      "default": "NIFTI_GZ", 
+      "enum": [
+        "NIFTI_PAIR", 
+        "NIFTI_PAIR_GZ", 
+        "NIFTI_GZ", 
+        "NIFTI"
+      ]
+    }, 
+    "padding": {
+      "type": "boolean", 
+      "description": "improve BET if FOV is very small in Z (by temporarily padding end slices)", 
+      "optional": true
+    }, 
+    "radius": {
+      "type": "integer", 
+      "description": "head radius", 
+      "optional": true
+    }, 
+    "reduce_bias": {
+      "type": "boolean", 
+      "description": "bias field and neck cleanup", 
+      "optional": true
+    }, 
+    "remove_eyes": {
+      "type": "boolean", 
+      "description": "eye & optic nerve cleanup (can be useful in SIENA)", 
+      "optional": true
+    }, 
+    "robust": {
+      "type": "boolean", 
+      "description": "robust brain centre estimation (iterates BET several times)", 
+      "optional": true
+    }, 
+    "skull": {
+      "type": "boolean", 
+      "description": "create skull image", 
+      "optional": true
+    }, 
+    "surfaces": {
+      "type": "boolean", 
+      "description": "run bet2 and then betsurf to get additional skull and scalp surfaces (includes registrations)", 
+      "optional": true
+    }, 
+    "threshold": {
+      "type": "boolean", 
+      "description": "apply thresholding to segmented brain image and mask", 
+      "optional": true
+    }, 
+    "vertical_gradient": {
+      "type": "number", 
+      "description": "vertical gradient in fractional intensity threshold (-1, 1)", 
+      "optional": true
+    }
+  }, 
+  "inputs": {
+    "in_file": {
+      "description": "input file to skull strip", 
+      "base": "file"
+    }, 
+    "out_file": {
+      "description": "name of output skull stripped image", 
+      "optional": true, 
+      "base": "file"
+    }, 
+    "t2_guided": {
+      "description": "as with creating surfaces, when also feeding in non-brain-extracted T2 (includes registrations)", 
+      "optional": true, 
+      "base": "file"
+    }
+  }, 
+  "url": "http://nipype.readthedocs.io/en/1.0.3/interfaces/generated/interfaces.ants/registration.html", 
+  "source": "https://github.com/yarikoptic/gearificator", 
+  "custom": {
+    "gearificator": {
+      "interface": "nipype.interfaces.fsl.preprocess:BET", 
+      "outputs": {
+        "inskull_mask_file": {
+          "description": "path/name of inskull mask (if generated)"
+        }, 
+        "inskull_mesh_file": {
+          "description": "path/name of inskull mesh outline (if generated)"
+        }, 
+        "mask_file": {
+          "description": "path/name of binary brain mask (if generated)"
+        }, 
+        "meshfile": {
+          "description": "path/name of vtk mesh file (if generated)"
+        }, 
+        "out_file": {
+          "description": "path/name of skullstripped file (if generated)"
+        }, 
+        "outline_file": {
+          "description": "path/name of outline file (if generated)"
+        }, 
+        "outskin_mask_file": {
+          "description": "path/name of outskin mask (if generated)"
+        }, 
+        "outskin_mesh_file": {
+          "description": "path/name of outskin mesh outline (if generated)"
+        }, 
+        "outskull_mask_file": {
+          "description": "path/name of outskull mask (if generated)"
+        }, 
+        "outskull_mesh_file": {
+          "description": "path/name of outskull mesh outline (if generated)"
+        }, 
+        "skull_mask_file": {
+          "description": "path/name of skull mask (if generated)"
+        }
+      }, 
+      "category": "analysis"
+    }, 
+    "flywheel": {
+      "suite": "nipype:fsl"
+    }, 
+    "gear-builder": {
+      "image": "gearificator/nipype-interfaces-fsl-preprocess-bet:0.0.2.nipype.1.0.3.1"
+    }, 
+    "docker-image": "gearificator/nipype-interfaces-fsl-preprocess-bet:0.0.2.nipype.1.0.3.1"
+  }
+}

--- a/gears/gearificator/nipype-interfaces-fsl-preprocess-fast.json
+++ b/gears/gearificator/nipype-interfaces-fsl-preprocess-fast.json
@@ -1,0 +1,200 @@
+{
+  "name": "nipype-interfaces-fsl-preprocess-fast", 
+  "description": "FSL FAST command for segmentation and bias correction", 
+  "author": "Yaroslav O. Halchenko", 
+  "maintainer": "Yaroslav O. Halchenko <debian@onerussian.com>", 
+  "license": "Other", 
+  "version": "0.0.2.nipype.1.0.3.1", 
+  "config": {
+    "args": {
+      "type": "string", 
+      "description": "Additional parameters to the command", 
+      "optional": true
+    }, 
+    "bias_iters": {
+      "type": "integer", 
+      "description": "number of main-loop iterations during bias-field removal [default=1]", 
+      "default": 1, 
+      "minimum": 1, 
+      "maximum": 10
+    }, 
+    "bias_lowpass": {
+      "type": "integer", 
+      "description": "bias field smoothing extent (FWHM) in mm [default=4]", 
+      "default": 4, 
+      "minimum": 4, 
+      "maximum": 40
+    }, 
+    "hyper": {
+      "type": "number", 
+      "description": "segmentation spatial smoothness", 
+      "minimum": 0.0, 
+      "maximum": 1.0, 
+      "default": 0.0
+    }, 
+    "img_type": {
+      "type": "integer", 
+      "description": "int specifying type of image: (1 = T1, 2 = T2, 3 = PD) [default=1]", 
+      "default": 1, 
+      "enum": [
+        1, 
+        2, 
+        3
+      ]
+    }, 
+    "init_seg_smooth": {
+      "type": "number", 
+      "description": "initial segmentation spatial smoothness (during bias field estimation) [default=0.0001]", 
+      "default": 0.0001, 
+      "minimum": 0.0001, 
+      "maximum": 0.1
+    }, 
+    "iters_afterbias": {
+      "type": "integer", 
+      "description": "number of main-loop iterations after bias-field removal [default=1]", 
+      "default": 1, 
+      "minimum": 1, 
+      "maximum": 20
+    }, 
+    "mixel_smooth": {
+      "type": "number", 
+      "description": "spatial smoothness for mixeltype", 
+      "minimum": 0.0, 
+      "maximum": 1.0, 
+      "default": 0.0
+    }, 
+    "no_bias": {
+      "type": "boolean", 
+      "description": "do not remove bias field", 
+      "optional": true
+    }, 
+    "no_pve": {
+      "type": "boolean", 
+      "description": "turn off PVE (partial volume estimation)", 
+      "optional": true
+    }, 
+    "number_classes": {
+      "type": "integer", 
+      "description": "number of tissue-type classes [default=1]", 
+      "default": 1, 
+      "minimum": 1, 
+      "maximum": 10
+    }, 
+    "output_biascorrected": {
+      "type": "boolean", 
+      "description": "output restored image (bias-corrected image)", 
+      "optional": true
+    }, 
+    "output_biasfield": {
+      "type": "boolean", 
+      "description": "output estimated bias field", 
+      "optional": true
+    }, 
+    "output_type": {
+      "type": "string", 
+      "description": "FSL output type [default=NIFTI_GZ]", 
+      "default": "NIFTI_GZ", 
+      "enum": [
+        "NIFTI_PAIR", 
+        "NIFTI_PAIR_GZ", 
+        "NIFTI_GZ", 
+        "NIFTI"
+      ]
+    }, 
+    "probability_maps": {
+      "type": "boolean", 
+      "description": "outputs individual probability maps", 
+      "optional": true
+    }, 
+    "segment_iters": {
+      "type": "integer", 
+      "description": "number of segmentation-initialisation iterations [default=1]", 
+      "default": 1, 
+      "minimum": 1, 
+      "maximum": 50
+    }, 
+    "segments": {
+      "type": "boolean", 
+      "description": "outputs a separate binary image for each tissue type", 
+      "optional": true
+    }, 
+    "use_priors": {
+      "type": "boolean", 
+      "description": "use priors throughout", 
+      "optional": true
+    }, 
+    "verbose": {
+      "type": "boolean", 
+      "description": "switch on diagnostic messages", 
+      "optional": true
+    }
+  }, 
+  "inputs": {
+    "in_files": {
+      "description": "image, or multi-channel set of images, to be segmented", 
+      "base": "file"
+    }, 
+    "init_transform": {
+      "description": "<standard2input.mat> initialise using priors", 
+      "optional": true, 
+      "base": "file"
+    }, 
+    "manual_seg": {
+      "description": "Filename containing intensities", 
+      "optional": true, 
+      "base": "file"
+    }, 
+    "other_priors": {
+      "description": "alternative prior images", 
+      "optional": true, 
+      "base": "file"
+    }, 
+    "out_basename": {
+      "description": "base name of output files", 
+      "optional": true, 
+      "base": "file"
+    }
+  }, 
+  "url": "http://nipype.readthedocs.io/en/1.0.3/interfaces/generated/interfaces.ants/registration.html", 
+  "source": "https://github.com/yarikoptic/gearificator", 
+  "custom": {
+    "gearificator": {
+      "interface": "nipype.interfaces.fsl.preprocess:FAST", 
+      "outputs": {
+        "bias_field": {
+          "description": "Bias field"
+        }, 
+        "mixeltype": {
+          "description": "path/name of mixeltype volume file _mixeltype"
+        }, 
+        "partial_volume_files": {
+          "description": "Partial volume files"
+        }, 
+        "partial_volume_map": {
+          "description": "path/name of partial volume file _pveseg"
+        }, 
+        "probability_maps": {
+          "description": "Probability maps"
+        }, 
+        "restored_image": {
+          "description": "Restored image"
+        }, 
+        "tissue_class_files": {
+          "description": "Tissue class files"
+        }, 
+        "tissue_class_map": {
+          "description": "path/name of binary segmented volume file one val for each class  _seg"
+        }
+      }, 
+      "category": "analysis"
+    }, 
+    "flywheel": {
+      "suite": "nipype:fsl"
+    }, 
+    "gear-builder": {
+      "image": "gearificator/nipype-interfaces-fsl-preprocess-fast:0.0.2.nipype.1.0.3.1"
+    }, 
+    "docker-image": "gearificator/nipype-interfaces-fsl-preprocess-fast:0.0.2.nipype.1.0.3.1"
+  }, 
+  "label": "FAST"
+}


### PR DESCRIPTION
- ANTS:
  - N4BiasFieldCorrection
- FSL
  - BET
  - FAST

Details from `datalad run` for the commit which recorded which command performed the action
(`--gear spec` was done to not regenerate docker images)

```json
{
 "pwd": ".",
 "cmd": [
  "gearificator",
  "spec",
  "process",
  "--regex",
  ".*(BET|FAST|N4BiasFieldCorrection)",
  "--run-tests",
  "gear",
  "--gear",
  "spec",
  "--gear",
  "docker-push",
  "--gear",
  "exchange",
  "."
 ],
 "exit": 0,
 "chain": []
}
```
