### PR TITLE
scitran/dcm2niix:0.5.4_1.0.20180328

### DIFF
--- a/gears/scitran/dcm2niix.json
+++ b/gears/scitran/dcm2niix.json
@@ -1,3 +1,4 @@
+
 {
   "name": "dcm2niix",
   "label": "DCM2NIIX: dcm2nii DICOM to NIfTI converter",
@@ -8,9 +9,9 @@
   "source": "https://github.com/scitran-apps/dcm2niix",
   "license": "BSD-2-Clause",
   "flywheel": "0",
-  "version": "0.5.2_1.0.20180328",
+  "version": "0.5.4_1.0.20180328",
   "custom": {
-    "docker-image": "scitran/dcm2niix:0.5.2_1.0.20180328"
+    "docker-image": "scitran/dcm2niix:0.5.4_1.0.20180328"
   },
   "config": {
     "decompress_dicoms": {
@@ -78,7 +79,7 @@
       "default": "n",
       "id": "-s"
     },
-    "3Dvol": {
+    "vol3D": {
       "description": "Output 3D uncompressed volumes (true/false, default=false). Note that the filename flag will be set to '-f %p_%s' to prevent overwriting files",
       "type": "boolean",
       "default": false
@@ -90,9 +91,9 @@
       "id": "-d"
     },
     "convert_only_series": {
-      "description": "only convert this series number - can be used up to 16 times (default convert all). Provide series numbers in a space-separated list within single quotes, e.g., '12 13'",
+      "description": "only convert this series number - can be used up to 16 times (default convert all). Provide series numbers in a space-separated list e.g., '12 13'",
       "type": "string",
-      "default": "'all'",
+      "default": "all",
       "id": "-n"
     }
   },


### PR DESCRIPTION
https://github.com/scitran-apps/dcm2niix/releases/tag/0.5.4_1.0.20180328