### PR TITLE
flywheel/fsl-sienax:1.0.1_5.0

### DIFF
--- a/gears/flywheel/fsl-sienax.json
+++ b/gears/flywheel/fsl-sienax.json
@@ -8,16 +8,16 @@
   "url": "https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/SIENA",
   "source": "https://github.com/flywheel-apps/fsl-siena-sienax",
   "cite": "S.M. Smith, Y. Zhang, M. Jenkinson, J. Chen, P.M. Matthews, A. Federico, and N. De Stefano. Accurate, robust and automated longitudinal and cross-sectional brain change analysis. NeuroImage, 17(1):479-489, 2002.  S.M. Smith, M. Jenkinson, M.W. Woolrich, C.F. Beckmann, T.E.J. Behrens, H. Johansen-Berg, P.R. Bannister, M. De Luca, I. Drobnjak, D.E. Flitney, R. Niazy, J. Saunders, J. Vickers, Y. Zhang, N. De Stefano, J.M. Brady, and P.M. Matthews. Advances in functional and structural MR image analysis and implementation as FSL. NeuroImage, 23(S1):208-219, 2004.",
-  "version": "1.0.0_5.0",
+  "version": "1.0.1_5.0",
   "custom": {
     "flywheel": {
       "suite": "FSL"
     },
     "gear-builder": {
       "category": "analysis",
-      "image": "flywheel/fsl-sienax:1.0.0_5.0"
+      "image": "flywheel/fsl-sienax:1.0.1_5.0"
     },
-    "docker-image": "flywheel/fsl-sienax:1.0.0_5.0"
+    "docker-image": "flywheel/fsl-sienax:1.0.1_5.0"
   },
   "inputs": {
     "key": {


### PR DESCRIPTION
updated Dockerfile to use flywheel/fsl-siena:1.0.1_5.0

updated promoted file and archive naming logic for fsl-siena/siena-x

moved optibet logic into the run.py for easier versioning