### PR TITLE
v0.7.10 partial acquisition correction

### DIFF
--- a/gears/scitran/dcm2niix.json
+++ b/gears/scitran/dcm2niix.json
@@ -8,9 +8,9 @@
   "source": "https://github.com/scitran-apps/dcm2niix",
   "license": "BSD-2-Clause",
   "flywheel": "0",
-  "version": "0.7.9_1.0.20190410",
+  "version": "0.7.10_1.0.20190410",
   "custom": {
-    "docker-image": "scitran/dcm2niix:0.7.9_1.0.20190410",
+    "docker-image": "scitran/dcm2niix:0.7.10_1.0.20190410",
     "flywheel": {
       "uid": 1000,
       "gid": 1000,
@@ -18,7 +18,7 @@
     },
     "gear-builder": {
       "category": "converter",
-      "image": "scitran/dcm2niix:0.7.9_1.0.20190410"
+      "image": "scitran/dcm2niix:0.7.10_1.0.20190410"
     }
   },
   "config": {
@@ -111,6 +111,11 @@
     },
     "coil_combine": {
       "description": "For sequences with individual coil data, saved as individual volumes, this option will save a NIfTI file with ONLY the combined coil data (i.e., the last volume). Default=False. Warning: We make no effort to check for independent coil data, we simply trust that if you have selcted this option you know what you are asking for.",
+      "type": "boolean",
+      "default": false
+    },
+    "remove_incomplete_volumes": {
+      "description": "Some 4D scans can be aborted mid-acquisition after any number of complete volume acquisitions.  The final volume may be incomplete, which causes problems during dcm2niix reconstruction.  Check this to scan the dicom archive before reconstruction and remove the files associated with the trailing incomplete volume.  All other volumes will be reconstructed as normal. ",
       "type": "boolean",
       "default": false
     }


### PR DESCRIPTION
Added correction routine for partial acquisition (sequences aborted mid-scan)
Uses software from the following repo: https://github.com/VisionandCognition/NHP-Process-MRI/blob/master/bin/fix_dcm_vols