### PR TITLE
flywheel/roi2nix:0.2.3

### DIFF
--- a/gears/flywheel/roi2nix.json
+++ b/gears/flywheel/roi2nix.json
@@ -8,12 +8,12 @@
     "url": "",
     "source": "https://github.com/flywheel-apps/ROI2nix",
     "cite": "",
-    "version": "0.2.0",
+    "version": "0.2.3",
     "custom": {
-        "docker-image": "flywheel/roi2nix:0.2.0",
+        "docker-image": "flywheel/roi2nix:0.2.3",
         "gear-builder": {
             "category": "analysis",
-            "image": "flywheel/roi2nix:0.2.0"
+            "image": "flywheel/roi2nix:0.2.3"
         }
     },
     "inputs": {
@@ -50,7 +50,7 @@
                 "int16",
                 "int32",
                 "int64"
-              ],
+            ],
             "type": "string"
         },
         "save_slicer_color_table": {


### PR DESCRIPTION
* FIX: Changes for accommodating ROI drawn on NIfTI files with alternate affines that diverge from the standard coordinate basis vectors.
* Must be installed with https://gitlab.com/flywheel-io/product/frontend/ohif-viewer/-/merge_requests/76