### PR TITLE
release CMRR-physio v1.2.7

### DIFF
--- a/gears/flywheel/extract-cmrr-physio.json
+++ b/gears/flywheel/extract-cmrr-physio.json
@@ -8,12 +8,12 @@
   "source": "https://github.com/flywheel-apps/extract-cmrr-physio/releases",
   "license": "MIT",
   "flywheel": "0",
-  "version": "1.2.4",
+  "version": "1.2.7",
   "custom": {
-    "docker-image": "flywheel/extract-cmrr-physio:1.2.4",
+    "docker-image": "flywheel/extract-cmrr-physio:1.2.7",
     "gear-builder": {
       "category": "converter",
-      "image": "flywheel/extract-cmrr-physio:1.2.4"
+      "image": "flywheel/extract-cmrr-physio:1.2.7"
 
     }
   },


### PR DESCRIPTION
FIX: filenames in .metadata.json no longer contain absolute path
ENH: Zipped dicoms not nested in a folder are handled correctly.