### PR TITLE
Update bids-mriqc url

### DIFF
--- a/gears/flywheel/bids-mriqc.json
+++ b/gears/flywheel/bids-mriqc.json
@@ -2,12 +2,12 @@
   "name": "bids-mriqc",
   "label": "BIDS MRIQC: Automatic prediction of quality and visual reporting of MRI scans in BIDS format",
   "description": "MRIQC (0.15.2 - April 6, 2020) extracts no-reference image quality metrics (IQMs) from T1w and T2w structural and functional magnetic resonance imaging data.  Note: arguments --n_procs --mem_gb and --ants-nthreads are not availble to configure becaues they are set to use the maximum available as detected by MRIQC.",
-  "version": "1.2.1_0.15.2",
+  "version": "1.2.2_0.15.2",
   "custom": {
-    "docker-image": "flywheel/bids-mriqc:1.2.1_0.15.2",
+    "docker-image": "flywheel/bids-mriqc:1.2.2_0.15.2",
     "gear-builder": {
       "category": "analysis",
-      "image": "flywheel/bids-mriqc:1.2.1_0.15.2"
+      "image": "flywheel/bids-mriqc:1.2.2_0.15.2"
     },
     "flywheel": {
       "suite": "BIDS Apps"
@@ -267,6 +267,6 @@
   "maintainer": "Flywheel <support@flywheel.io>",
   "cite": "Esteban O, Birman D, Schaer M, Koyejo OO, Poldrack RA, Gorgolewski KJ; MRIQC: Advancing the Automatic Prediction of Image Quality in MRI from Unseen Sites; PLOS ONE 12(9):e0184661; doi:10.1371/journal.pone.0184661.",
   "license": "BSD-3-Clause",
-  "source": "https://github.com/flywheel-apps/bids-mriqc",
+  "source": "https://gitlab.com/flywheel-io/flywheel-apps/bids-mriqc",
   "url": "https://mriqc.readthedocs.io/en/stable/about.html"
 }


### PR DESCRIPTION
The URL for the exchange incorrectly listed GitHub as the host.