### PR TITLE
Fix get bids info

### DIFF
--- a/gears/flywheel/curate-bids.json
+++ b/gears/flywheel/curate-bids.json
@@ -6,11 +6,11 @@
   "maintainer": "Flywheel <support@flywheel.io>",
   "source": "https://gitlab.com/flywheel-io/flywheel-apps/curate-bids",
   "url": "https://bids.neuroimaging.io/",
-  "version": "2.1.1_1.0.0",
+  "version": "2.1.2_1.0.1",
   "custom": {
     "gear-builder": {
       "category": "analysis",
-      "image": "flywheel/curate-bids:2.1.1_1.0.0"
+      "image": "flywheel/curate-bids:2.1.2_1.0.1"
     },
     "flywheel": {
       "suite": "BIDS"


### PR DESCRIPTION
FIX: get_bids_info()
The gear calls get_bids_info() to get the BIDS Curation report data.  If it passes in a session ID, only info for that session is returned.  Now it passes an empty string if session_only is False (if it is running on something more than just the session).
ENH: 1.0.1 of the bids-client
This also uses version 1.0.1 of the bids-client which has an improved ReproIn template (subject names have special characters removed and MEGRE/MESE acquisitions are handled by anat_file)