### PR TITLE
Combined ROI output handles file extensions better

### DIFF
--- a/gears/flywheel/roi2nix.json
+++ b/gears/flywheel/roi2nix.json
@@ -8,12 +8,12 @@
     "url": "",
     "source": "https://github.com/flywheel-apps/ROI2nix",
     "cite": "",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "custom": {
-        "docker-image": "flywheel/roi2nix:0.3.3",
+        "docker-image": "flywheel/roi2nix:0.3.4",
         "gear-builder": {
             "category": "analysis",
-            "image": "flywheel/roi2nix:0.3.3"
+            "image": "flywheel/roi2nix:0.3.4"
         }
     },
     "inputs": {


### PR DESCRIPTION
gear used to crash when saving combined bitmask roi file if the source file ended in anything but ".dcm"