### PR TITLE
Update to v1.1.10

### DIFF
--- a/gears/flywheel/export-rois.json
+++ b/gears/flywheel/export-rois.json
@@ -7,11 +7,11 @@
   "license": "MIT",
   "source": "https://github.com/flywheel-apps/ROI_export",
   "url": "https://github.com/flywheel-apps/ROI_export",
-  "version": "1.1.1",
+  "version": "1.1.10",
   "custom": {
     "gear-builder": {
       "category": "analysis",
-      "image": "flywheel/export-rois:1.1.1"
+      "image": "flywheel/export-rois:1.1.10"
     },
     "flywheel": {
       "suite": "Metadata I/O"


### PR DESCRIPTION
Addresses issue where old ohif used inconsistent capitalization of metadata Keys