### PR TITLE
Update form-and-annotations-exporter.json to 0.0.4

### DIFF
--- a/gears/flywheel/form-and-annotations-exporter.json
+++ b/gears/flywheel/form-and-annotations-exporter.json
@@ -37,13 +37,13 @@
     }
   },
   "custom": {
-    "docker-image": "flywheel/form-and-annotations-exporter:0.0.3",
+    "docker-image": "flywheel/form-and-annotations-exporter:0.0.4",
     "flywheel": {
       "suite": "Curation"
     },
     "gear-builder": {
       "category": "analysis",
-      "image": "flywheel/form-and-annotations-exporter:0.0.3"
+      "image": "flywheel/form-and-annotations-exporter:0.0.4"
     }
   },
   "description": "Export Form Responses and/or Annotations to CSV file(s).",
@@ -59,5 +59,5 @@
   "name": "form-and-annotations-exporter",
   "source": "https://gitlab.com/flywheel-io/scientific-solutions/gears/form-and-annotations-exporter",
   "url": "https://gitlab.com/flywheel-io/scientific-solutions/gears/form-and-annotations-exporter",
-  "version": "0.0.3"
+  "version": "0.0.4"
 }


### PR DESCRIPTION
#### Changelog

- `units` of measure (e.g. mm) column in Annotations CSV
- `Session Timestamp` column in Form Responses and Annotation CSVs
- `data_dictionary.csv` on top level for both CSVs
- Sample Code in README for:
  - Converting "narrow" to "wide" CSV format.
  - Merging the wide-formated Form Responses and Annotation CSVs