### PR TITLE
ENH: Add pushing to artifact registry instead of cloud storage.

### DIFF
--- a/bin/process-manifests.sh
+++ b/bin/process-manifests.sh
@@ -8,6 +8,7 @@ EXCHANGE_JSON="exchange.json"
 
 GEAR_SCHEMA_URL="https://raw.githubusercontent.com/flywheel-io/gears/master/spec/manifest.schema.json"
 BOUTIQUE_SCHEMA_URL="https://raw.githubusercontent.com/boutiques/boutiques/master/schema/descriptor.schema.json"
+EXCHANGE_ARTIFACT_REGISTRY_URL="docker://us-docker.pkg.dev/flywheel-exchange/gear-exchange"
 
 GIT_REMOTE=${GIT_REMOTE:-"origin"}
 GIT_BRANCH="$( git rev-parse --abbrev-ref HEAD )"
@@ -235,15 +236,21 @@ function process_manifests() {
                 docker_image="$( jq -r '."container-image"."image"' $manifest_path )"
                 manifest_version=""
             fi
+            echo "Pulling image $docker_image"
+            docker pull $docker_image
+            # Get docker image digest
+            digest=$(docker inspect $docker_image | jq -r '.[0].RepoDigests[0]')
+            # Strip off just the sha256 hash value
+            sha256=$(printf "$digest" | sed 's/.*\://')
 
-            container=$( docker create $docker_image /bin/true )
-            rootfs_path="$tempdir/$manifest_slug.tgz"
-            >&2 echo "Exporting container"
-            docker export $container | gzip -n > $rootfs_path
-            shasum=$( sha384sum $rootfs_path | cut -d " " -f 1 )
-            #docker rm $container # fails on CircleCI
+#            container=$( docker create $docker_image /bin/true )
+#            rootfs_path="$tempdir/$manifest_slug.tgz"
+#            >&2 echo "Exporting container"
+#            docker export $container | gzip -n > $rootfs_path
+#            shasum=$( sha384sum $rootfs_path | cut -d " " -f 1 )
+#            #docker rm $container # fails on CircleCI
 
-            v_manifest_name="$manifest_slug-sha384-$shasum"
+            v_manifest_name="$manifest_slug-sha256-$sha256"
             v_manifest_path="$MANIFESTS_DIR/$manifest_hier/$v_manifest_name.json"
             mkdir -p "$MANIFESTS_DIR/$manifest_hier"
 
@@ -252,7 +259,9 @@ function process_manifests() {
             jq ".exchange.\"git-commit\" = \"$GIT_COMMIT_CURRENT\"" $v_manifest_path \
                 > $tempfile && mv $tempfile $v_manifest_path
 
-            jq ".exchange.\"rootfs-hash\" = \"sha384:$shasum\" | .exchange.\"rootfs-url\" = \"$EXCHANGE_DOWNLOAD_URL/$v_manifest_name.tgz\"" $v_manifest_path \
+            jq ".exchange.\"rootfs-hash\" = \"sha256:$shasum\" |
+                .exchange.\"rootfs-url\" =
+                    \"$EXCHANGE_ARTIFACT_REGISTRY_URL/$manifest_slug@sha256:$sha256\"" $v_manifest_path \
                 > $tempfile && mv $tempfile $v_manifest_path
 
             invocation_schema=$( derive_invocation_schema $manifest_type $manifest_path )
@@ -260,14 +269,18 @@ function process_manifests() {
                 > $tempfile && mv $tempfile $v_manifest_path
             >&2 echo "Invocation schema generated for $manifest_type $manifest_name"
 
-            rootfs_hash_path="$tempdir/$v_manifest_name.tgz"
-            mv $rootfs_path $rootfs_hash_path
-            gsutil cp $rootfs_hash_path $EXCHANGE_BUCKET_URI
-            BUILD_ARTIFACTS="$BUILD_ARTIFACTS $EXCHANGE_BUCKET_URI/${rootfs_hash_path##*/}"
+#            rootfs_hash_path="$tempdir/$v_manifest_name.tgz"
+#            mv $rootfs_path $rootfs_hash_path
+#            gsutil cp $rootfs_hash_path $EXCHANGE_BUCKET_URI
+#            BUILD_ARTIFACTS="$BUILD_ARTIFACTS $EXCHANGE_BUCKET_URI/${rootfs_hash_path##*/}"
 
-            exchange_image="$GCR_HOST_PROJECT/$manifest_slug:$manifest_version"
+#            exchange_image="$GCR_HOST_PROJECT/$manifest_slug:$manifest_version"
+            exchange_image = "$EXCHANGE_ARTIFACT_REGISTRY_URL/$manifest_slug:$manifest_version"
             docker tag $docker_image $exchange_image
-            gcloud docker -- push $exchange_image
+            cat $GCLOUD_SERVICE_ACCOUNT_FILE | docker login -u _json_key_base64 \
+                --password-stdin \
+                https://us-docker.pkg.dev
+            docker push $exchange_image
 
             git add $v_manifest_path
             echo $GIT_COMMIT_CURRENT > $SENTINEL_FILENAME

--- a/bin/process-manifests.sh
+++ b/bin/process-manifests.sh
@@ -8,7 +8,7 @@ EXCHANGE_JSON="exchange.json"
 
 GEAR_SCHEMA_URL="https://raw.githubusercontent.com/flywheel-io/gears/master/spec/manifest.schema.json"
 BOUTIQUE_SCHEMA_URL="https://raw.githubusercontent.com/boutiques/boutiques/master/schema/descriptor.schema.json"
-EXCHANGE_ARTIFACT_REGISTRY_URL="docker://us-docker.pkg.dev/flywheel-exchange/gear-exchange"
+EXCHANGE_ARTIFACT_REGISTRY_URL="us-docker.pkg.dev/flywheel-exchange/gear-exchange"
 
 GIT_REMOTE=${GIT_REMOTE:-"origin"}
 GIT_BRANCH="$( git rev-parse --abbrev-ref HEAD )"
@@ -256,7 +256,7 @@ function process_manifests() {
 
                 jq ".exchange.\"rootfs-hash\" = \"sha256:$shasum\" |
                     .exchange.\"rootfs-url\" =
-                        \"$EXCHANGE_ARTIFACT_REGISTRY_URL/$manifest_slug@sha256:$sha256\"" $v_manifest_path \
+                        \"docker://$EXCHANGE_ARTIFACT_REGISTRY_URL/$manifest_slug@sha256:$sha256\"" $v_manifest_path \
                     > $tempfile && mv $tempfile $v_manifest_path
 
                 invocation_schema=$( derive_invocation_schema $manifest_type $manifest_path )
@@ -264,7 +264,7 @@ function process_manifests() {
                     > $tempfile && mv $tempfile $v_manifest_path
                 >&2 echo "Invocation schema generated for $manifest_type $manifest_name"
 
-                exchange_image = "$EXCHANGE_ARTIFACT_REGISTRY_URL/$manifest_slug:$manifest_version"
+                exchange_image="$EXCHANGE_ARTIFACT_REGISTRY_URL/$manifest_slug:$manifest_version"
                 docker tag $docker_image $exchange_image
                 cat $GCLOUD_SERVICE_ACCOUNT_FILE | docker login -u _json_key_base64 \
                     --password-stdin \


### PR DESCRIPTION
Add feature flag under `.custom.flywheel.beta_exchange = true` to enable pushing to artifact registry instead of google cloud storage