### PR TITLE
release form-and-annotations-exporter:0.1.1

### DIFF
--- a/gears/flywheel/form-and-annotations-exporter.json
+++ b/gears/flywheel/form-and-annotations-exporter.json
@@ -40,10 +40,10 @@
     },
     "gear-builder": {
       "category": "analysis",
-      "image": "flywheel/form-and-annotations-exporter:0.1.0"
+      "image": "flywheel/form-and-annotations-exporter:0.1.1"
     }
   },
-  "description": "Export Form Responses and/or Annotations to CSV file(s). ",
+  "description": "Export Form Responses and/or Annotations to CSV file(s).",
   "environment": {
     "FLYWHEEL": "/flywheel/v0",
     "GPG_KEY": "E3FF2839C048B25C084DEBE9B26995E310250568",
@@ -67,5 +67,5 @@
   "name": "form-and-annotations-exporter",
   "source": "https://gitlab.com/flywheel-io/scientific-solutions/gears/form-and-annotations-exporter",
   "url": "https://gitlab.com/flywheel-io/scientific-solutions/gears/form-and-annotations-exporter",
-  "version": "0.1.0"
+  "version": "0.1.1"
 }


### PR DESCRIPTION
Modified the get_sdk_client function to use api_client.config.api_key to get the currently used key rather than client.auth_status.info.api_key.key which can only use the Legacy Key from the logged-in user.